### PR TITLE
[#15] 메인페이지 레이아웃 추가

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -32,5 +32,7 @@ module.exports = {
     'react/function-component-definition': 'off',
     'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
+    'arrow-body-style': 'off',
+    'object-curly-newline': 0,
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@ant-design/icons": "^5.2.6",
         "@chakra-ui/react": "^2.8.2",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
@@ -59,6 +60,38 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@ant-design/colors": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@ant-design/colors/-/colors-7.0.0.tgz",
+      "integrity": "sha512-iVm/9PfGCbC0dSMBrz7oiEXZaaGH7ceU40OJEfKmyuzR9R5CRimJYPlRiFtMQGQcbNMea/ePcoIebi4ASGYXtg==",
+      "dependencies": {
+        "@ctrl/tinycolor": "^3.4.0"
+      }
+    },
+    "node_modules/@ant-design/icons": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons/-/icons-5.2.6.tgz",
+      "integrity": "sha512-4wn0WShF43TrggskBJPRqCD0fcHbzTYjnaoskdiJrVHg86yxoZ8ZUqsXvyn4WUqehRiFKnaclOhqk9w4Ui2KVw==",
+      "dependencies": {
+        "@ant-design/colors": "^7.0.0",
+        "@ant-design/icons-svg": "^4.3.0",
+        "@babel/runtime": "^7.11.2",
+        "classnames": "^2.2.6",
+        "rc-util": "^5.31.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0",
+        "react-dom": ">=16.0.0"
+      }
+    },
+    "node_modules/@ant-design/icons-svg": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@ant-design/icons-svg/-/icons-svg-4.3.1.tgz",
+      "integrity": "sha512-4QBZg8ccyC6LPIRii7A0bZUk3+lEDCLnhB+FVsflGdcWPPmV+j3fire4AwwoqHV/BibgvBmR9ZIo4s867smv+g=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.22.13",
@@ -1568,6 +1601,14 @@
       "peerDependencies": {
         "@chakra-ui/system": ">=2.0.0",
         "react": ">=18"
+      }
+    },
+    "node_modules/@ctrl/tinycolor": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@ctrl/tinycolor/-/tinycolor-3.6.1.tgz",
+      "integrity": "sha512-SITSV6aIXsuVNV3f3O0f2n/cgyEDWoSqtZMYiAmcsYHydcKrOz3gUxB/iXd/Qf08+IZX4KpgNbvUdMBmWz+kcA==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@emotion/babel-plugin": {
@@ -3217,6 +3258,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
+      "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw=="
     },
     "node_modules/cli-cursor": {
       "version": "4.0.0",
@@ -6058,6 +6104,24 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/rc-util": {
+      "version": "5.38.1",
+      "resolved": "https://registry.npmjs.org/rc-util/-/rc-util-5.38.1.tgz",
+      "integrity": "sha512-e4ZMs7q9XqwTuhIK7zBIVFltUtMSjphuPPQXHoHlzRzNdOwUxDejo0Zls5HYaJfRKNURcsS/ceKVULlhjBrxng==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "react-is": "^18.2.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0"
+      }
+    },
+    "node_modules/rc-util/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/react": {
       "version": "18.2.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@ant-design/icons": "^5.2.6",
     "@chakra-ui/react": "^2.8.2",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",

--- a/src/@types/interface.ts
+++ b/src/@types/interface.ts
@@ -21,3 +21,10 @@ export interface ModalDataProps {
   heading: string;
   text: string;
 }
+
+export interface HomeCardProps {
+  name: any;
+  category: any;
+  score: any;
+  price: any;
+}

--- a/src/components/Layout/Navigation.tsx
+++ b/src/components/Layout/Navigation.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import { theme } from '../../styles/theme';
+import TopBtn from '../TopBtn';
 
 function Navigation() {
   return (
@@ -7,6 +8,7 @@ function Navigation() {
       <StyledItem>홈</StyledItem>
       <StyledItem>홈</StyledItem>
       <StyledItem>홈</StyledItem>
+      <TopBtn />
     </StyledContainer>
   );
 }
@@ -14,6 +16,7 @@ function Navigation() {
 export default Navigation;
 
 const StyledContainer = styled.div`
+  position: relative;
   display: flex;
   flex-direction: row;
   justify-content: space-between;

--- a/src/components/TopBtn/index.tsx
+++ b/src/components/TopBtn/index.tsx
@@ -1,0 +1,29 @@
+import styled from '@emotion/styled';
+import { UpOutlined } from '@ant-design/icons';
+import { theme } from '../../styles/theme';
+
+const ScrollToTop = () => {
+  window.scrollTo(0, 0);
+};
+
+function TopBtn() {
+  return (
+    <StyledBtn onClick={ScrollToTop}>
+      <UpOutlined />
+    </StyledBtn>
+  );
+}
+
+export default TopBtn;
+
+const StyledBtn = styled.button`
+  position: absolute;
+  right: 10px;
+  bottom: 80px;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background-color: ${theme.colors.white};
+  box-shadow: ${theme.shadows.shadow3.shadow};
+  z-index: 10;
+`;

--- a/src/pages/Home/ContentsContainer.tsx
+++ b/src/pages/Home/ContentsContainer.tsx
@@ -1,0 +1,43 @@
+import styled from '@emotion/styled';
+import HomeCard from './HomeCard';
+import { HomeCardProps } from '../../@types/interface';
+
+const dummy = [
+  { name: '신라호텔', category: '호텔/리조트', score: 4.9, price: 123400 },
+  { name: '백제호텔', category: '호텔/리조트', score: 4.8, price: 122000 },
+  { name: '미국호텔', category: '호텔/리조트', score: 4.5, price: 132000 },
+  { name: '일본호텔', category: '호텔/리조트', score: 3.0, price: 52000 },
+  { name: '중국호텔', category: '호텔/리조트', score: 4.2, price: 122000 },
+  { name: '뉴욕호텔', category: '호텔/리조트', score: 4.1, price: 124300 },
+  { name: '파리호텔', category: '호텔/리조트', score: 4.5, price: 124200 },
+  { name: '로마호텔', category: '호텔/리조트', score: 4.9, price: 124300 },
+];
+
+const ContentsContainer = () => {
+  return (
+    <StyledContainer>
+      {dummy.map((e: HomeCardProps) => {
+        return (
+          <HomeCard
+            key={e.price * e.score}
+            name={e.name}
+            category={e.category}
+            score={e.score}
+            price={e.price}
+          />
+        );
+      })}
+    </StyledContainer>
+  );
+};
+
+export default ContentsContainer;
+
+const StyledContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 8rem;
+  width: 100%;
+`;

--- a/src/pages/Home/HomeCard.tsx
+++ b/src/pages/Home/HomeCard.tsx
@@ -1,0 +1,80 @@
+import styled from '@emotion/styled';
+import { StarFilled } from '@ant-design/icons';
+import { Text } from '@chakra-ui/react';
+import { theme } from '../../styles/theme';
+import { HomeCardProps } from '../../@types/interface';
+
+const HomeCard = ({ name, category, score, price }: HomeCardProps) => {
+  return (
+    <StyledCard>
+      <StyledImgWrapper />
+      <StyledInfoContainer>
+        <StyledCardHeader>
+          <Text as="p" size="lg">
+            {name}
+          </Text>
+          <StyledScoreWrapper>
+            <StarFilled
+              style={{ color: theme.colors.blue400, fontSize: '1rem' }}
+            />
+            <StyledScoreDigit>{score}</StyledScoreDigit>
+          </StyledScoreWrapper>
+        </StyledCardHeader>
+        <StyledCategoryWrapper>{category}</StyledCategoryWrapper>
+        <StyledPriceWrapper>{`₩ ${price}원/박`}</StyledPriceWrapper>
+      </StyledInfoContainer>
+    </StyledCard>
+  );
+};
+
+export default HomeCard;
+
+const StyledCard = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin: 1rem;
+  width: 45%;
+
+  background-color: ${theme.colors.white};
+  border-radius: 8px;
+
+  @media screen and (max-width: 700px) {
+    width: 90%;
+  }
+`;
+
+const StyledImgWrapper = styled.div`
+  width: 100%;
+  height: 300px;
+  border-radius: 8px;
+  box-shadow: ${theme.shadows.shadow3.shadow};
+`; // 추후 슬라이드 컴포넌트로 대체
+
+const StyledInfoContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  padding: 2rem 1rem 0rem 1rem;
+`;
+
+const StyledCardHeader = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const StyledScoreWrapper = styled.div`
+  min-width: 50px;
+`;
+
+const StyledScoreDigit = styled.span`
+  padding-left: 5px;
+`;
+
+const StyledCategoryWrapper = styled.div`
+  color: ${theme.colors.gray400};
+`;
+
+const StyledPriceWrapper = styled.div`
+  padding-top: 1rem;
+`;

--- a/src/pages/Home/HomeHeader.tsx
+++ b/src/pages/Home/HomeHeader.tsx
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+import SearchBtn from './SearchBtn';
+import MenuBar from './MenuBar';
+import { theme } from '../../styles/theme';
+
+function HomeHeader() {
+  return (
+    <StyledContainer>
+      <SearchBtn />
+      <MenuBar />
+    </StyledContainer>
+  );
+}
+
+export default HomeHeader;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  position: fixed;
+  top: 0;
+  padding-top: 1rem;
+  width: ${theme.device.tablet};
+  box-shadow: ${theme.shadows.shadow1.shadow};
+  background-color: ${theme.colors.white};
+
+  @media screen and (max-width: ${theme.device.tablet}) {
+    width: 100%;
+  }
+`;

--- a/src/pages/Home/MenuBar.tsx
+++ b/src/pages/Home/MenuBar.tsx
@@ -1,0 +1,50 @@
+import styled from '@emotion/styled';
+import { useParams, useNavigate } from 'react-router-dom';
+import { Button } from '@chakra-ui/react';
+import { theme } from '../../styles/theme';
+
+const Category = ['호텔·리조트', '한옥', '펜션·풀빌라', '모텔', '게스트하우스'];
+
+function MenuBar() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  return (
+    <StyledContainer>
+      {Category.map((item: string | any) => (
+        <Button
+          className={item}
+          onClick={() => {
+            navigate(`/${item}`);
+          }}
+          key={item}
+          padding={3}
+          margin={2}
+          width="100px"
+          size="s"
+          shadow={theme.shadows.shadow1.shadow}
+          variant={id === item ? 'blue' : 'gray'}
+        >
+          {item}
+        </Button>
+      ))}
+    </StyledContainer>
+  );
+}
+
+export default MenuBar;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: center;
+  padding: 2rem;
+  width: 100%;
+  height: 40px;
+
+  @media screen and (max-width: ${theme.device.tablet}) {
+    justify-content: flex-start;
+    overflow: auto;
+  }
+`;

--- a/src/pages/Home/SearchBtn.tsx
+++ b/src/pages/Home/SearchBtn.tsx
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+import { SearchOutlined } from '@ant-design/icons';
+import { theme } from '../../styles/theme';
+
+function SearchBtn() {
+  return (
+    <StyledContainer>
+      <StyledTextContainer>국내/국외, 날짜, 인원 수 추가</StyledTextContainer>
+      <SearchOutlined style={{ color: theme.colors.gray400 }} />
+    </StyledContainer>
+  );
+}
+
+export default SearchBtn;
+
+const StyledContainer = styled.button`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 70%;
+  min-width: 300px;
+  height: 50px;
+  padding: 0rem 2rem 0rem 2rem;
+  border: 2px solid ${theme.colors.gray100};
+  border-radius: 24px;
+  box-shadow: ${theme.shadows.shadow1.shadow};
+
+  &:hover {
+    background-color: ${theme.colors.gray50};
+  }
+`;
+
+const StyledTextContainer = styled.div`
+  color: ${theme.colors.gray400};
+`;

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,0 +1,21 @@
+import styled from '@emotion/styled';
+import HomeHeader from './HomeHeader';
+import ContentsContainer from './ContentsContainer';
+
+function Home() {
+  return (
+    <StyledContainer>
+      <HomeHeader />
+      <ContentsContainer />
+    </StyledContainer>
+  );
+}
+
+export default Home;
+
+const StyledContainer = styled.div`
+  display: flex;
+  justify-content: center;
+  width: 100%;
+  min-height: 100vh;
+`;

--- a/src/routes/MainRouter.tsx
+++ b/src/routes/MainRouter.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import { theme } from '../styles/theme';
 import Navigation from '../components/Layout/Navigation';
 import Footer from '../components/Layout/Footer';
+import Home from '../pages/Home';
 import Test from '../pages/test/Test';
 
 function Dashboard() {
@@ -21,7 +22,8 @@ function MainRouter() {
       <StyledInnerContainer>
         <Routes>
           <Route path="/" element={<Dashboard />}>
-            <Route index element={<>This is home!</>} />
+            <Route index element={<Home />} />
+            <Route path="/:id" element={<Home />} />
             <Route path="/test" element={<Test />} />
           </Route>
         </Routes>
@@ -48,12 +50,12 @@ const StyledInnerContainer = styled.div`
   position: relative;
   overflow-y: auto;
   padding: 1rem;
-  width: 768px;
+  width: ${theme.device.tablet};
 
   background-color: ${theme.colors.white};
   box-shadow: ${theme.shadows.shadow1.shadow};
 
-  @media screen and (max-width: 768px) {
+  @media screen and (max-width: ${theme.device.tablet}) {
     width: 100%;
   }
 `;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -95,4 +95,8 @@ export const theme = {
       shadow: '0px -1px 8px rgba(0, 0, 0, 0.04)',
     },
   },
+  device: {
+    tablet: '768px',
+    mobile: '380px',
+  },
 };


### PR DESCRIPTION
## 개요

- 메인페이지 기본 레이아웃 추가
- eslint rule 설정

close #15 

## 스크린샷
###  홈페이지 레이아웃 구현 ( 검색헤더, 숙소 리스팅, 탑버튼 )
<img width="1100" alt="스크린샷 2023-11-23 오후 4 39 02" src="https://github.com/TeamOHJO/Frontend/assets/83493231/527ea2b4-3b82-405e-9744-3ded066eb10e">

### eslint rule 추가
![스크린샷 2023-11-23 오후 4 41 28](https://github.com/TeamOHJO/Frontend/assets/83493231/bf643097-2cc4-4293-a18f-6c1687fe8438)

- 화살표함수 규칙 비활성화 : 해당 규칙으로 설정해야 이전 커밋에서 오류가 나지 않습니다!
- 객체 내 개행 규칙 비활성화 : 객체값 안에서 한줄마다 개행을 해줘야하는 규칙 제거했습니다


  
## 구현 사항

- [x] 검색헤더 레이아웃 구현
- [x] 숙소 리스팅 레이아웃 구현
- [x] 탑버튼 구현


## 고민한 점, 질문거리

- 가능한 eslint rule을 추가하지 않는 방향으로 가면 좋을 것 같습니다.
만약 추가해야하는 부분이 있다면, 추가 후 이전 npm run lint 실행 후 이전 기록들과 충돌이 없는지 먼저 확인부탁드립니다!
그리고 pr이나 회의 때 공지해주시면 좋을 것 같습니다 

- 모바일 웹앱뷰이기 때문에 TopBtn을 아무 페이지나 적용하는 것에 애로사항이 있습니다. 사용이 필요할 시 저에게 말씀 주시면 적용방법 같이 고민해 볼 수 있을 것 같아요! 

- npm ci 부탁드립니다!