### PR TITLE
[#29] 마이페이지 상단 탭 디자인 및 컴포넌트 생성

### DIFF
--- a/src/pages/MyPage/MyPageInfo.tsx
+++ b/src/pages/MyPage/MyPageInfo.tsx
@@ -1,0 +1,5 @@
+function MyPageInfo() {
+  return <div>내 정보 관리</div>;
+}
+
+export default MyPageInfo;

--- a/src/pages/MyPage/MyPageReservation.tsx
+++ b/src/pages/MyPage/MyPageReservation.tsx
@@ -1,0 +1,5 @@
+function MyPageReservation() {
+  return <div>예약/취소 내역</div>;
+}
+
+export default MyPageReservation;

--- a/src/pages/MyPage/MyPageReview.tsx
+++ b/src/pages/MyPage/MyPageReview.tsx
@@ -1,0 +1,5 @@
+function MyPageReview() {
+  return <div>내 리뷰</div>;
+}
+
+export default MyPageReview;

--- a/src/pages/MyPage/MyPageTabs.tsx
+++ b/src/pages/MyPage/MyPageTabs.tsx
@@ -1,0 +1,29 @@
+import { Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react';
+import MyPageReservation from './MyPageReservation';
+import MyPageReview from './MyPageReview';
+import MyPageInfo from './MyPageInfo';
+
+function MyPageTabs() {
+  return (
+    <Tabs isFitted size="sm" colorScheme="blue" variant="enclosed">
+      <TabList mb="1em">
+        <Tab>예약/취소 내역</Tab>
+        <Tab>내 리뷰</Tab>
+        <Tab>내 정보 관리</Tab>
+      </TabList>
+      <TabPanels>
+        <TabPanel>
+          <MyPageReservation />
+        </TabPanel>
+        <TabPanel>
+          <MyPageReview />
+        </TabPanel>
+        <TabPanel>
+          <MyPageInfo />
+        </TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+}
+
+export default MyPageTabs;

--- a/src/pages/MyPage/MyPageTabs.tsx
+++ b/src/pages/MyPage/MyPageTabs.tsx
@@ -5,9 +5,9 @@ import MyPageInfo from './MyPageInfo';
 
 function MyPageTabs() {
   return (
-    <Tabs isFitted size="sm" colorScheme="blue" variant="enclosed">
+    <Tabs isFitted size="md" variant="enclosed">
       <TabList mb="1em">
-        <Tab>예약/취소 내역</Tab>
+        <Tab>예약 내역</Tab>
         <Tab>내 리뷰</Tab>
         <Tab>내 정보 관리</Tab>
       </TabList>

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,0 +1,25 @@
+import styled from '@emotion/styled';
+import { Center, Text } from '@chakra-ui/react';
+import MyPageTabs from './MyPageTabs';
+
+function MyPage() {
+  return (
+    <StyledContainer>
+      <Center height="90px">
+        <Text as="p" size="sm" textAlign="center">
+          000님, 같이 여행을 즐겨요
+        </Text>
+      </Center>
+      <MyPageTabs />
+    </StyledContainer>
+  );
+}
+
+export default MyPage;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: calc(100vh - 74px);
+`;

--- a/src/routes/MainRouter.tsx
+++ b/src/routes/MainRouter.tsx
@@ -9,6 +9,7 @@ import Test from '../pages/test/Test';
 import Basket from '../pages/Basket';
 import WishList from '../pages/WishList';
 import Room from '../pages/Room';
+import MyPage from '../pages/MyPage';
 
 function Dashboard() {
   return (
@@ -31,6 +32,7 @@ function MainRouter() {
             <Route path="/test" element={<Test />} />
             <Route path="/wishlist" element={<WishList />} />
             <Route path="/basket" element={<Basket />} />
+            <Route path="/mypage" element={<MyPage />} />
           </Route>
           <Route path="/accommodation/:id" element={<Accommodation />} />
           <Route path="/accommodation/:id/:id" element={<Room />} />


### PR DESCRIPTION
## 개요

- 마이페이지 상단 탭 디자인
- 마이페이지 탭 내부 컴포넌트 생성
  - 예약/취소 내역 -> `MyPageReservation.tsx`
  - 내 리뷰 -> `MyPageReview.tsx`
  - 내 정보 관리 -> `MyPageInfo.tsx`

Close #29 

## 스크린샷

| |모바일|글자 수정|
|--|--|--|
|medium 사이즈 (차크라 탭 UI 기본 사이즈)|![스크린샷 2023-11-23 오후 10 27 01](https://github.com/TeamOHJO/Frontend/assets/139190686/b22d8a23-231d-4def-aafc-a5b175382cd8)|![스크린샷 2023-11-23 오후 10 27 16](https://github.com/TeamOHJO/Frontend/assets/139190686/0efb032b-251e-4838-b5e7-8ff66de7ff2f)|
|small 사이즈|![스크린샷 2023-11-23 오후 10 21 38](https://github.com/TeamOHJO/Frontend/assets/139190686/f8b4d6bd-849c-4ab0-95ae-d3343ed65adc)|![스크린샷 2023-11-23 오후 10 36 03](https://github.com/TeamOHJO/Frontend/assets/139190686/2411e32b-077a-4742-924f-4b9698018b24)|


## 구현 사항

- [x] 마이페이지 상단 탭 디자인
- [x] 마이페이지 탭 내부 컴포넌트 생성
마이페이지에서 사용할 컴포넌트 생성해두었습니다.
하연님은 `MyPageReservation.tsx`, 재훈님은 `MyPageReview.tsx`, 저는 `MyPageInfo.tsx`에서 작업하면 됩니다.
각 컴포넌트 내부에서 추가 컴포넌트 생성은 자유롭게 하시면 됩니다.

## 고민한 점, 질문거리

- 문제점) 피그마 디자인대로 탭 디자인했을 때 문제점이 `예약/취소 내역`의 글자가 넘쳐서 줄바꿈이 발생합니다.
- 해결방법1) 탭의 사이즈를 medium -> small로 줄이되, 원래대로 글자를 다 넣는다.
- 해결방법2) 탭의 사이즈는 그대로 두고, 글자 수를 줄인다. (`예약/취소 내역` 를 `예약 내역`으로 변경)

첨부한 사진 확인 후 한 분씩 의견 남겨주시면 해당 내용으로 수정 후 push하겠습니다!
