### PR TITLE
[#40] 내 정보관리 초안

### DIFF
--- a/src/pages/MyPage/MyPageInfo/InfoInput.tsx
+++ b/src/pages/MyPage/MyPageInfo/InfoInput.tsx
@@ -1,0 +1,81 @@
+import styled from '@emotion/styled';
+import { useState } from 'react';
+import { Input, Button } from '@chakra-ui/react';
+
+interface InfoInputProps {
+  name: string;
+  list: string;
+  item: any;
+  onChangeInput: any;
+}
+
+function InfoInput({ name, list, item, onChangeInput }: InfoInputProps) {
+  const [onClicked, setOnClicked] = useState(false);
+
+  return (
+    <StyledInfoWrapper>
+      <StyledInfoLabel>{list}</StyledInfoLabel>
+      <StyledInfoInput
+        name={name}
+        disabled={!onClicked}
+        value={item}
+        onChange={onChangeInput}
+      />
+      {!onClicked ? (
+        <StyledEditBtn
+          variant="blue"
+          size="md"
+          onClick={() => {
+            setOnClicked(true);
+          }}
+        >
+          수정하기
+        </StyledEditBtn>
+      ) : (
+        <StyledSubmitBtn
+          colorScheme="blue"
+          onClick={() => {
+            setOnClicked(false);
+          }}
+        >
+          수정완료
+        </StyledSubmitBtn>
+      )}
+    </StyledInfoWrapper>
+  );
+}
+
+export default InfoInput;
+
+const StyledInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 1.5rem 1rem 1.5rem 1rem;
+
+  width: 80%;
+
+  @media screen and (max-width: 500px) {
+    width: 95%;
+  }
+`;
+
+const StyledInfoLabel = styled.span`
+  flex: 0.5;
+  font-weight: 500;
+  @media screen and (max-width: 500px) {
+    flex: 1;
+  }
+`;
+
+const StyledInfoInput = styled(Input)`
+  flex: 1.5;
+`;
+
+const StyledEditBtn = styled(Button)`
+  flex: 0.5;
+`;
+
+const StyledSubmitBtn = styled(Button)`
+  flex: 0.5;
+`;

--- a/src/pages/MyPage/MyPageInfo/index.tsx
+++ b/src/pages/MyPage/MyPageInfo/index.tsx
@@ -1,11 +1,125 @@
+import styled from '@emotion/styled';
+import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Button, useDisclosure } from '@chakra-ui/react';
+import { RightOutlined } from '@ant-design/icons';
+import { theme } from '../../../styles/theme';
 import MyPageSubtitle from '../MyPageSubtitle';
+import DefaultModal from '../../../components/Modal/DefaultModal';
+import InfoInput from './InfoInput';
 
 function MyPageInfo() {
+  const [userInfo, setUserInfo] = useState({
+    email: 'rlaxmrgml@naver.com',
+    userName: '김특희',
+    phoneNum: '010-1234-5678',
+  });
+
+  const { email, userName, phoneNum } = userInfo;
+  const navigate = useNavigate();
+  const { onOpen, isOpen, onClose } = useDisclosure();
+
+  const modalData = {
+    heading: '회원 탈퇴',
+    text: '회원을 탈퇴하시겠습니까?',
+  };
+
+  const modalFunc = () => {
+    console.log('회원탈퇴 api 전송');
+    alert('탈퇴되셨습니다');
+    navigate('/');
+  };
+
+  const onChangeInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setUserInfo({
+      ...userInfo,
+      [name]: value,
+    });
+  };
+
   return (
-    <div>
+    <StyledContainer>
       <MyPageSubtitle subtitle="내 정보 관리" />
-    </div>
+
+      <StyledInnerContainer>
+        <StyledInfoWrapper>
+          <StyledInfoLabel>이메일</StyledInfoLabel>
+          <StyledInfoDetail>{email}</StyledInfoDetail>
+        </StyledInfoWrapper>
+        <InfoInput
+          name="userName"
+          list="이름"
+          item={userName}
+          onChangeInput={onChangeInput}
+        />
+        <InfoInput
+          name="phoneNum"
+          list="전화번호"
+          item={phoneNum}
+          onChangeInput={onChangeInput}
+        />
+
+        <StyledResignBtn
+          variant="blue"
+          size="md"
+          rightIcon={<RightOutlined />}
+          onClick={onOpen}
+        >
+          회원탈퇴
+        </StyledResignBtn>
+        <DefaultModal
+          isOpen={isOpen}
+          onClose={onClose}
+          modalFunc={modalFunc}
+          modalData={modalData}
+        />
+      </StyledInnerContainer>
+    </StyledContainer>
   );
 }
 
 export default MyPageInfo;
+
+const StyledContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+`;
+
+const StyledInnerContainer = styled(StyledContainer)`
+  margin-top: 3rem;
+  align-items: center;
+`;
+
+const StyledResignBtn = styled(Button)`
+  display: flex;
+  align-items: center;
+  margin-top: 7rem;
+`;
+
+const StyledInfoWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 1.5rem 1rem 1.5rem 1rem;
+  width: 80%;
+
+  @media screen and (max-width: 500px) {
+    width: 95%;
+  }
+`;
+
+const StyledInfoLabel = styled.span`
+  flex: 1;
+  font-weight: 500;
+  @media screen and (max-width: 500px) {
+    flex: 1.5;
+  }
+`;
+
+const StyledInfoDetail = styled.span`
+  flex: 4;
+  color: ${theme.colors.gray400};
+`;


### PR DESCRIPTION
## 개요
- 내 정보 관리 초안

close #40

## 스크린샷
- 내 정보 관리 초안 추가했습니다!
<img width="779" alt="스크린샷 2023-11-25 오후 11 55 40" src="https://github.com/TeamOHJO/Frontend/assets/83493231/836685ef-503e-4361-a193-3e59df2900af">

  
## 구현 사항

- [ ] 회원탈퇴 버튼
- [ ] 정보 수정 기능

## 고민한 점, 질문거리

- 비밀번호 수정 관련해서는, 현재 비밀번호 확인 api도 추가로 요청을 해야하기 때문에 초안에 포함시키지는 않았습니다.
   마이페이지의 정보수정기능이 높은 우선순위는 아니기 때문에, 필수적인 기능부터 구현하고 백엔드 분들이랑 조율이 필요할 것 같습니다!
   보완할 부분들은 메인페이지 우선적으로 끝내고, 다시 작업해보도록 하겠습니다