### PR TITLE
[#53] 위시리스트 API 제외한 기능 구현

### DIFF
--- a/public/data/wishlist.json
+++ b/public/data/wishlist.json
@@ -1,0 +1,29 @@
+[
+  {
+    "accommodationId": 1,
+    "accommodationName": "일본 도쿄 Nakano City",
+    "category": "호텔/리조트",
+    "location": "강원도 강릉시 옥계면 헌화로 455-34",
+    "image": "https://www.lottehotel.com/content/dam/lotte-hotel/city/mapo/overview/introduction/190725-1-768-ove-LTMA.png.thumb.768.768.jpg",
+    "lowestPrice": 99000,
+    "isLiked": true
+  },
+  {
+    "accommodationId": 2,
+    "accommodationName": "하늘펜션",
+    "category": "펜션/풀빌라",
+    "location": "강원도 춘천시 남산면 북한강변길 688",
+    "image": "https://a.cdn-hotels.com/gdcs/production20/d1674/580b8765-0cb7-4dc5-a955-194d06ee3205.jpg",
+    "lowestPrice": 210000,
+    "isLiked": true
+  },
+  {
+    "accommodationId": 3,
+    "accommodationName": "호텔 스퀘어 제주",
+    "category": "호텔/리조트",
+    "location": "제주특별자치도 제주시 서부두2길 26",
+    "image": "https://www.take-hotel.com/TakeHotel_common/images/homepage/index/slider_01.jpg",
+    "lowestPrice": 99000,
+    "isLiked": true
+  }
+]

--- a/src/@types/interface.ts
+++ b/src/@types/interface.ts
@@ -154,3 +154,13 @@ export interface BasketData {
   stars: number;
   canReserve: boolean;
 }
+
+export interface WishlistData {
+  accommodationId: number;
+  accommodationName: string;
+  category: string;
+  location: string;
+  image: string;
+  lowestPrice: number;
+  isLiked: boolean;
+}

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -58,6 +58,6 @@ export const getBasket = async () => {
 };
 
 export const DeleteBasketItem = async (basketId: number) => {
-  const res = await client.delete(`/basket/${basketId}`);
+  const res = await clientToken.delete(`/basket/${basketId}`);
   return res;
 };

--- a/src/pages/Basket/BasketDisabledCard.tsx
+++ b/src/pages/Basket/BasketDisabledCard.tsx
@@ -13,6 +13,7 @@ import {
 import { StarFilled, CloseOutlined } from '@ant-design/icons';
 import { BasketData } from '../../@types/interface';
 import { basketDataState } from '../../states/atom';
+import { DeleteBasketItem } from '../../api';
 
 function BasketDisabledCard({ item }: { item: BasketData }) {
   const [basketData, setBasketData] = useRecoilState(basketDataState);
@@ -22,7 +23,7 @@ function BasketDisabledCard({ item }: { item: BasketData }) {
     new Date(item.endDate).getDate() - new Date(item.startDate).getDate();
 
   const deleteSingleItem = async (id: number) => {
-    // await DeleteBasketItem(id);
+    await DeleteBasketItem(id);
     setBasketData(
       basketData.filter((product: BasketData) => product.basketId !== id),
     );

--- a/src/pages/Basket/BasketTabs.tsx
+++ b/src/pages/Basket/BasketTabs.tsx
@@ -25,6 +25,7 @@ import {
 } from '../../states/atom';
 import DefaultModal from '../../components/Modal/DefaultModal';
 import BasketNoProducts from './BasketNoProducts';
+import { DeleteBasketItem } from '../../api';
 
 function BasketTabs() {
   const [basketData, setBasketData] = useRecoilState(basketDataState);
@@ -36,7 +37,7 @@ function BasketTabs() {
 
   const deleteAllUnavailable = () => {
     // api 수정 후 주석 제거 예정
-    // unavailableIds.forEach((id: number) => DeleteBasketItem(id));
+    unavailableIds.forEach((id: number) => DeleteBasketItem(id));
     setBasketData(
       basketData.filter(
         (product: BasketData) => !unavailableIds.includes(product.basketId),
@@ -46,7 +47,7 @@ function BasketTabs() {
 
   const deleteCheckedItems = () => {
     // api 수정 후 주석 제거 예정
-    // checkedIds.forEach((checkedId: number) => DeleteBasketItem(checkedId));
+    checkedIds.forEach((checkedId: number) => DeleteBasketItem(checkedId));
     setBasketData(
       basketData.filter(
         (product: BasketData) => !checkedIds.includes(product.basketId),

--- a/src/pages/Basket/BasketTabs.tsx
+++ b/src/pages/Basket/BasketTabs.tsx
@@ -36,7 +36,6 @@ function BasketTabs() {
   const unavailableIds = useRecoilValue(getUnavailableIds);
 
   const deleteAllUnavailable = () => {
-    // api 수정 후 주석 제거 예정
     unavailableIds.forEach((id: number) => DeleteBasketItem(id));
     setBasketData(
       basketData.filter(
@@ -46,7 +45,6 @@ function BasketTabs() {
   };
 
   const deleteCheckedItems = () => {
-    // api 수정 후 주석 제거 예정
     checkedIds.forEach((checkedId: number) => DeleteBasketItem(checkedId));
     setBasketData(
       basketData.filter(

--- a/src/pages/Basket/index.tsx
+++ b/src/pages/Basket/index.tsx
@@ -27,7 +27,6 @@ function Basket() {
         },
       );
       const data = await response.json();
-      console.log(data);
 
       // Sort the data by startDate
       data.sort(

--- a/src/pages/WishList/WishListCard.tsx
+++ b/src/pages/WishList/WishListCard.tsx
@@ -8,10 +8,13 @@ import {
   CardBody,
   Stack,
 } from '@chakra-ui/react';
-import { EnvironmentOutlined, HeartFilled } from '@ant-design/icons';
-import { theme } from '../../styles/theme';
+import { EnvironmentOutlined } from '@ant-design/icons';
+import { WishlistData } from '../../@types/interface';
+import Heart from '../../components/Heart';
+import { handleBadgeColor } from '../../utils/handleBadgeColor';
 
-function WishListCard() {
+function WishListCard({ item }: { item: WishlistData }) {
+  const badgeColor = handleBadgeColor(item.category);
   return (
     <Card size="sm">
       <CardBody display="flex" flexDirection="row" gap={3}>
@@ -19,7 +22,7 @@ function WishListCard() {
           boxSize="110px"
           objectFit="cover"
           borderRadius={8}
-          src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcTD3JBW-cAhYqwYXsEK9AosV69_t1SNqh5RYA&usqp=CAU"
+          src={item.image}
           alt="Accomodation Photo"
         />
         <Stack width="100%">
@@ -28,26 +31,24 @@ function WishListCard() {
             justifyContent="space-between"
             alignItems="center"
           >
-            <Heading size="sm">일본 도쿄 Nakano City</Heading>
-            <HeartFilled
-              style={{
-                fontSize: '20px',
-                color: theme.colors.red500,
-                cursor: 'pointer',
-              }}
-            />
+            <Heading size="sm">{item.accommodationName}</Heading>
+            <Heart isLiked={item.isLiked} />
           </Box>
           <Box textAlign="left">
-            <Badge variant="blue">펜션/풀빌라</Badge>
+            <Badge variant={badgeColor}>{item.category}</Badge>
           </Box>
           <Box display="flex" alignItems="center" gap={1}>
-            <EnvironmentOutlined />
+            <EnvironmentOutlined
+              style={{
+                color: '#848484',
+              }}
+            />
             <Text as="span" size="xs" color="gray.84">
-              강원도 강릉시 옥계면 헌화로 455-34
+              {item.location}
             </Text>
           </Box>
           <Text as="span" size="sm" color="gray.84" textAlign="right">
-            ·최소 금액 ￦99,000원
+            ·최소 금액 ￦{item.lowestPrice.toLocaleString()}
           </Text>
         </Stack>
       </CardBody>

--- a/src/pages/WishList/index.tsx
+++ b/src/pages/WishList/index.tsx
@@ -23,7 +23,6 @@ function WishList() {
   useEffect(() => {
     fetchData();
   }, []);
-  console.log(wishlistData);
 
   return (
     <StyledContainer>

--- a/src/pages/WishList/index.tsx
+++ b/src/pages/WishList/index.tsx
@@ -1,8 +1,30 @@
+import { useEffect } from 'react';
+import { useRecoilState } from 'recoil';
 import styled from '@emotion/styled';
 import { Box, Center, Heading, Grid } from '@chakra-ui/react';
 import WishListCard from './WishListCard';
+import { wishlistDataState } from '../../states/atom';
+import { WishlistData } from '../../@types/interface';
 
 function WishList() {
+  const [wishlistData, setWishlistData] = useRecoilState(wishlistDataState);
+  const fetchData = async () => {
+    try {
+      const response = await fetch('http://localhost:5173/data/wishlist.json', {
+        method: 'GET',
+      });
+      const data = await response.json();
+      setWishlistData(data);
+    } catch (err) {
+      console.log(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchData();
+  }, []);
+  console.log(wishlistData);
+
   return (
     <StyledContainer>
       <StyledInnerContainer>
@@ -17,9 +39,9 @@ function WishList() {
             gap={4}
             px="1rem"
           >
-            <WishListCard />
-            <WishListCard />
-            <WishListCard />
+            {wishlistData.map((item: WishlistData) => (
+              <WishListCard key={item.accommodationId} item={item} />
+            ))}
           </Grid>
         </Box>
       </StyledInnerContainer>

--- a/src/states/atom.ts
+++ b/src/states/atom.ts
@@ -1,5 +1,5 @@
 import { atom, selector } from 'recoil';
-import { AlertData, BasketData } from '../@types/interface';
+import { AlertData, BasketData, WishlistData } from '../@types/interface';
 
 export const toastPopupState = atom<AlertData>({
   key: 'toastPopupState',
@@ -77,4 +77,9 @@ export const getUnavailableIds = selector({
     );
     return unavailableIds;
   },
+});
+
+export const wishlistDataState = atom<WishlistData[]>({
+  key: 'wishlistDataState',
+  default: [],
 });


### PR DESCRIPTION
## 개요

- 위시리스트 API 제외한 기능
- 전체 회의 도중에 장바구니 삭제 api 테스트해보느라 장바구니 삭제 API 요청 로직 이번 pr에 같이 포함해서 올라갑니다...

Close #53 

## 스크린샷

### 처음 위시리스트 페이지 진입 시
<img width="1710" alt="스크린샷 2023-11-27 오후 6 22 49" src="https://github.com/TeamOHJO/Frontend/assets/139190686/8f848e3f-fdae-4224-979e-d950d5466cc9">

  
## 구현 사항

- [x] 위시리스트 목 데이터 생성
- [x] 위시리스트 목록 불러오기
- [x] 좋아요 버튼 클릭 시 로직 추가
- [x] location 아이콘 회색으로 바꾸기

## 고민한 점, 질문거리

좋아요 버튼 로직 `components > Heart.tsx` 가져와서 썼습니다.
하트사이즈 관련해서 정민님이 `fontSize` props 추가해주신다고 하셔서 추후에 상세 API 연결하면서 다시 수정하겠습니다.
