### PR TITLE
refact: 토스트팝업 마우스오버 버그 수정

### DIFF
--- a/src/@types/interface.ts
+++ b/src/@types/interface.ts
@@ -234,3 +234,9 @@ export interface AddReviewData {
   images?: string[];
   star: number;
 }
+
+export interface HomeHeartToastPopupProps {
+  status: AlertData;
+  setFunc: Dispatch<SetStateAction<AlertData>>;
+  setShowPopUp: Dispatch<SetStateAction<boolean>>;
+}

--- a/src/pages/Home/HomeHeart.tsx
+++ b/src/pages/Home/HomeHeart.tsx
@@ -16,6 +16,7 @@ function HomeHeart({ liked, size, id }: HeartProps) {
   const [isHeart, setIsHeart] = useState<boolean>(liked);
   const [activeHeart, setActiveHeart] = useState(false);
   const accessToken = getCookie('token');
+  const [showPopUp, setShowPopUp] = useState(false);
 
   function handleIsHeart() {
     if (accessToken) {
@@ -31,6 +32,7 @@ function HomeHeart({ liked, size, id }: HeartProps) {
   });
 
   const openFunction = () => {
+    setShowPopUp(true);
     const toastData = {
       active: true,
       message: '로그인 후 진행하실 수 있습니다.',
@@ -94,7 +96,13 @@ function HomeHeart({ liked, size, id }: HeartProps) {
           }}
         />
       )}
-      <HomeHeartToastPopup status={showAlert} setFunc={setShowAlert} />
+      {showPopUp ? (
+        <HomeHeartToastPopup
+          status={showAlert}
+          setFunc={setShowAlert}
+          setShowPopUp={setShowPopUp}
+        />
+      ) : null}
     </StyledHeart>
   );
 }

--- a/src/pages/Home/HomeHeartToastPopUp.tsx
+++ b/src/pages/Home/HomeHeartToastPopUp.tsx
@@ -1,10 +1,15 @@
 import { useEffect, FunctionComponent } from 'react';
 import { Alert, AlertIcon, CloseButton, AlertDescription, Fade } from '@chakra-ui/react';
-import { ToastPopupProps } from '../../@types/interface';
+import { HomeHeartToastPopupProps } from '../../@types/interface';
 
-const HomeHeartToastPopup: FunctionComponent<ToastPopupProps> = ({ status, setFunc }) => {
+const HomeHeartToastPopup: FunctionComponent<HomeHeartToastPopupProps> = ({
+  status,
+  setFunc,
+  setShowPopUp,
+}) => {
   const onClose = () => {
     setFunc({ active: false, message: status.message });
+    setShowPopUp(false);
   };
 
   useEffect(() => {
@@ -12,6 +17,7 @@ const HomeHeartToastPopup: FunctionComponent<ToastPopupProps> = ({ status, setFu
     if (status.active) {
       const timer = setTimeout(() => {
         setFunc({ active: false, message: status.message });
+        setShowPopUp(false);
       }, 5000);
       return () => {
         clearTimeout(timer);
@@ -22,7 +28,12 @@ const HomeHeartToastPopup: FunctionComponent<ToastPopupProps> = ({ status, setFu
   }, [status.active]);
 
   return (
-    <Fade in={status.active}>
+    <Fade
+      in={status.active}
+      onMouseOver={(event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+        event.stopPropagation();
+      }}
+    >
       <Alert
         borderRadius={4}
         height="64px"

--- a/src/pages/Home/MenuBar.tsx
+++ b/src/pages/Home/MenuBar.tsx
@@ -1,6 +1,8 @@
 import styled from '@emotion/styled';
+import { useRef } from 'react';
 import { useRecoilState } from 'recoil';
 import { useParams, useNavigate } from 'react-router-dom';
+import { RightCircleOutlined, LeftCircleOutlined } from '@ant-design/icons';
 import { Button } from '@chakra-ui/react';
 import { theme } from '../../styles/theme';
 import { searchFilteredState } from '../../states/atom';
@@ -12,6 +14,19 @@ function MenuBar() {
   const { id } = useParams();
   const navigate = useNavigate();
   const [searchFilter, setSearchFilter] = useRecoilState(searchFilteredState);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const handleLeftBtnClick = () => {
+    if (containerRef.current) {
+      containerRef.current.scrollLeft = 0;
+    }
+  };
+  const handleRightBtnClick = () => {
+    if (containerRef.current) {
+      const maxScroll = containerRef.current.scrollWidth - containerRef.current.clientWidth;
+      containerRef.current.scrollLeft = maxScroll;
+    }
+  };
 
   const selectCategory = (item: string) => {
     navigate(`/${item}`);
@@ -22,7 +37,7 @@ function MenuBar() {
   };
 
   return (
-    <StyledContainer>
+    <StyledContainer ref={containerRef}>
       <Button
         className="호텔·리조트"
         onClick={() => {
@@ -54,6 +69,12 @@ function MenuBar() {
           {item}
         </Button>
       ))}
+      <StyledLeftBtn onClick={handleLeftBtnClick}>
+        <LeftCircleOutlined />
+      </StyledLeftBtn>
+      <StyledRightBtn onClick={handleRightBtnClick}>
+        <RightCircleOutlined />
+      </StyledRightBtn>
     </StyledContainer>
   );
 }
@@ -62,15 +83,53 @@ export default MenuBar;
 
 const StyledContainer = styled.div`
   display: flex;
+  position: relative;
   flex-direction: row;
   justify-content: center;
   align-items: center;
-  padding: 2rem;
+  padding: 2rem 3rem 2rem 3rem;
   width: 100%;
   height: 40px;
 
   @media screen and (max-width: ${theme.device.tablet}) {
     justify-content: flex-start;
-    overflow: auto;
+    overflow-x: scroll;
+    overflow-y: hidden;
+
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+`;
+
+const StyledLeftBtn = styled.div`
+  display: none;
+  position: fixed;
+  padding: 10px 15px 15px 10px;
+  left: 0;
+  background-color: ${theme.colors.white};
+  z-index: 10;
+  font-size: 30px;
+  color: ${theme.colors.gray500};
+  background: linear-gradient(to right, white 85%, transparent);
+
+  @media screen and (max-width: 550px) {
+    display: flex;
+  }
+`;
+
+const StyledRightBtn = styled.button`
+  display: none;
+  position: fixed;
+  padding: 10px 10px 15px 15px;
+  right: 0;
+  background-color: ${theme.colors.white};
+  z-index: 10;
+  font-size: 30px;
+  color: ${theme.colors.gray500};
+  background: linear-gradient(to left, white 85%, transparent);
+
+  @media screen and (max-width: 550px) {
+    display: flex;
   }
 `;


### PR DESCRIPTION
## 개요
- 토스트팝업 위치에 마우스 올릴 시, 숙소컴포넌트까지 마우스오버 되는 현상 제거했습니다.
- 메인페이지 카테고리바 슬라이더 버튼 구현 했습니다.

close #104 

## 스크린샷
- 토스트팝업 버그 수정 전 현상

https://github.com/TeamOHJO/Frontend/assets/83493231/349d968d-bfba-4cb6-8472-55963b5facce


- 슬라이더 버튼 구현

![스크린샷 2023-12-04 오전 2 32 31](https://github.com/TeamOHJO/Frontend/assets/83493231/b90e5f1d-5472-4521-bc0a-e2d819109ff6)


## 구현 사항

- [x] 토스트팝업 버튼 문제 해결
- [x] 숙박업소 카테고리 슬라이더 버튼 구현

## 고민한 점, 질문거리

- 토스트팝업의 위치가 하트아이콘에게 absolute로 잡혀있기 때문에, 하트아이콘을 누르면 숙소카드가 오버되는 것과 마찬가지로
   토스트팝업이 있는 곳을 오버하면 숙소카드가 오버되는 현상이였습니다.
- 토스트팝업의 mouseover 이벤트 발생 시, event.stopPropagation으로 막아보려 시도했지만 잘되지 않았네요.
- 고민하다가 상태관리를 통해 해당문제 없애줬습니다.
- 하트가 클릭되기 전 상태를 지정해주고, 클릭되기 전이라면 아예 토스트팝업을 렌더링하지 않는 방식으로 해결해봤습니다.
   (+ 리코일쓰지 않았습니다.)
