### PR TITLE
[#114] 장바구니, 위시리스트, 마이페이지(예약내역) api 분리

### DIFF
--- a/src/api/basket.ts
+++ b/src/api/basket.ts
@@ -7,7 +7,7 @@ export const getBasket = async () => {
 };
 
 // 장바구니 삭제
-export const DeleteBasketItem = async (basketId: number) => {
+export const deleteBasketItem = async (basketId: number) => {
   const res = await clientToken.delete(`/basket/${basketId}`);
   return res;
 };

--- a/src/api/basket.ts
+++ b/src/api/basket.ts
@@ -1,0 +1,13 @@
+import { clientToken } from './index';
+
+// 장바구니 목록 가져오기
+export const getBasket = async () => {
+  const res = await clientToken.get('/basket');
+  return res;
+};
+
+// 장바구니 삭제
+export const DeleteBasketItem = async (basketId: number) => {
+  const res = await clientToken.delete(`/basket/${basketId}`);
+  return res;
+};

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -162,12 +162,6 @@ export const getAccommodationList = async (
   }
 };
 
-// 위시리스트 목록 불러오기
-export const getWishlist = async () => {
-  const res = await clientToken.get('/wishlist');
-  return res;
-};
-
 // 좋아요 생성 & 해제
 export const clickLiked = async (accommodationId: number) => {
   const res = await clientToken.post(`/accommodation/${accommodationId}/likes`);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -6,14 +6,14 @@ import { AddReviewData } from '../@types/interface';
 axios.defaults.withCredentials = true;
 // const token = getCookie('token');
 
-const client = axios.create({
+export const client = axios.create({
   baseURL: import.meta.env.VITE_SERVER_URL,
   headers: {
     'content-type': import.meta.env.VITE_CONTENT_TYPE,
   },
 });
 
-const clientToken = axios.create({
+export const clientToken = axios.create({
   baseURL: import.meta.env.VITE_SERVER_URL,
   headers: {
     'content-type': import.meta.env.VITE_CONTENT_TYPE,
@@ -62,18 +62,6 @@ export const postLogout = async () => {
 
 export const testToken = async () => {
   const res = await clientToken.get('/user/test');
-  return res;
-};
-
-// 장바구니 가져오기
-export const getBasket = async () => {
-  const res = await clientToken.get('/basket');
-  return res;
-};
-
-// 장바구니 삭제
-export const DeleteBasketItem = async (basketId: number) => {
-  const res = await clientToken.delete(`/basket/${basketId}`);
   return res;
 };
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,10 +1,8 @@
 import axios from 'axios';
 import { JoinData, LoginData, Email, ReservationPostData } from './type';
 import { getCookie } from '../utils/utils';
-import { AddReviewData } from '../@types/interface';
 
 axios.defaults.withCredentials = true;
-// const token = getCookie('token');
 
 export const client = axios.create({
   baseURL: import.meta.env.VITE_SERVER_URL,
@@ -62,33 +60,6 @@ export const postLogout = async () => {
 
 export const testToken = async () => {
   const res = await clientToken.get('/user/test');
-  return res;
-};
-
-// 마이페이지 > 예약 취소 요청 API
-export const CancelReservation = async (reservationId: number) => {
-  const res = await clientToken.delete(`/reservation/${reservationId}`);
-  return res;
-};
-
-// 마이페이지 > 예약 내역 가져오기
-export const getMyPageReservationList = async () => {
-  const res = await clientToken.get('/reservation');
-  return res;
-};
-
-// 마이페이지 > 예약 취소 내역 가져오기
-export const getMyPageCancelledList = async () => {
-  const res = await clientToken.get('/reservation/canceled');
-  return res;
-};
-
-// 마이페이지 > 리뷰 작성
-export const SubmitReview = async (reservationId: number, reviewData: AddReviewData) => {
-  const res = await clientToken.post(
-    `/review/reservations/${reservationId}`,
-    JSON.stringify(reviewData),
-  );
   return res;
 };
 

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -2,7 +2,7 @@ import { AddReviewData } from '../@types/interface';
 import { clientToken } from './index';
 
 // 마이페이지 > 예약 취소 요청 API
-export const cancelReservation = async (reservationId: number) => {
+export const postCancelReservation = async (reservationId: number) => {
   const res = await clientToken.delete(`/reservation/${reservationId}`);
   return res;
 };

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -1,0 +1,29 @@
+import { AddReviewData } from '../@types/interface';
+import { clientToken } from './index';
+
+// 마이페이지 > 예약 취소 요청 API
+export const cancelReservation = async (reservationId: number) => {
+  const res = await clientToken.delete(`/reservation/${reservationId}`);
+  return res;
+};
+
+// 마이페이지 > 예약 내역 가져오기
+export const getMyPageReservationList = async () => {
+  const res = await clientToken.get('/reservation');
+  return res;
+};
+
+// 마이페이지 > 예약 취소 내역 가져오기
+export const getMyPageCancelledList = async () => {
+  const res = await clientToken.get('/reservation/canceled');
+  return res;
+};
+
+// 마이페이지 > 리뷰 작성
+export const submitReview = async (reservationId: number, reviewData: AddReviewData) => {
+  const res = await clientToken.post(
+    `/review/reservations/${reservationId}`,
+    JSON.stringify(reviewData),
+  );
+  return res;
+};

--- a/src/api/wishlist.ts
+++ b/src/api/wishlist.ts
@@ -1,0 +1,7 @@
+import { clientToken } from './index';
+
+// 위시리스트 목록 불러오기
+export const getWishlist = async () => {
+  const res = await clientToken.get('/wishlist');
+  return res;
+};

--- a/src/pages/AddReview/AddReviewForm.tsx
+++ b/src/pages/AddReview/AddReviewForm.tsx
@@ -5,9 +5,9 @@ import { Textarea, Heading, Button } from '@chakra-ui/react';
 import { theme } from '../../styles/theme';
 import StarRating from '../../components/StarRating';
 import AddReviewImages from './AddReviewImages';
-import { SubmitReview } from '../../api';
 import ToastPopup from '../../components/Modal/ToastPopup';
 import { addImage } from '../../utils/firebase';
+import { submitReview } from '../../api/mypage';
 
 function AddReviewForm() {
   const navigate = useNavigate();
@@ -56,7 +56,7 @@ function AddReviewForm() {
     } else if (reviewText !== '' && imageFile) {
       const imageURL = (await addImage(imageFile)) as string;
       try {
-        const response = await SubmitReview(reservationId, {
+        const response = await submitReview(reservationId, {
           ...reviewData,
           images: [imageURL],
         });
@@ -77,7 +77,7 @@ function AddReviewForm() {
       }
     } else if (reviewText !== '' && !imageFile) {
       try {
-        const response = await SubmitReview(reservationId, reviewData);
+        const response = await submitReview(reservationId, reviewData);
 
         if (response.data.code === 201) {
           console.log('등록 완료!');

--- a/src/pages/Basket/BasketCard.tsx
+++ b/src/pages/Basket/BasketCard.tsx
@@ -17,7 +17,6 @@ import { CloseOutlined, StarFilled } from '@ant-design/icons';
 import { theme } from '../../styles/theme';
 import { BasketData } from '../../@types/interface';
 import { handleBadgeColor } from '../../utils/handleBadgeColor';
-import { DeleteBasketItem } from '../../api';
 import { basketDataState } from '../../states/atom';
 import {
   changeCategoryReverseFormat,
@@ -26,6 +25,7 @@ import {
   countDay,
 } from '../../utils/utils';
 import DefaultModal from '../../components/Modal/DefaultModal';
+import { deleteBasketItem } from '../../api/basket';
 
 interface ToastData {
   active: boolean;
@@ -77,7 +77,7 @@ function BasketCard({ item, setShowAlert }: BasketCardProps) {
   };
 
   const deleteSingleItem = async (id: number) => {
-    await DeleteBasketItem(id);
+    await deleteBasketItem(id);
     setBasketData(basketData.filter((product: BasketData) => product.basketId !== id));
     toastFunc('숙소를 삭제하였습니다.');
   };

--- a/src/pages/Basket/BasketDisabledCard.tsx
+++ b/src/pages/Basket/BasketDisabledCard.tsx
@@ -5,8 +5,8 @@ import { Card, Image, Text, Box, CardBody, Badge, CardFooter } from '@chakra-ui/
 import { StarFilled, CloseOutlined } from '@ant-design/icons';
 import { BasketData } from '../../@types/interface';
 import { basketDataState } from '../../states/atom';
-import { DeleteBasketItem } from '../../api';
 import { changeCategoryReverseFormat, changeStarFormat, countDay } from '../../utils/utils';
+import { deleteBasketItem } from '../../api/basket';
 
 interface ToastData {
   active: boolean;
@@ -40,7 +40,7 @@ function BasketDisabledCard({ item, setShowAlert }: BasketCardProps) {
   };
 
   const deleteSingleItem = async (id: number) => {
-    await DeleteBasketItem(id);
+    await deleteBasketItem(id);
     setBasketData(basketData.filter((product: BasketData) => product.basketId !== id));
     toastFunc('숙소를 삭제하였습니다.');
   };

--- a/src/pages/Basket/BasketTabs.tsx
+++ b/src/pages/Basket/BasketTabs.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../states/atom';
 import DefaultModal from '../../components/Modal/DefaultModal';
 import BasketNoProducts from './BasketNoProducts';
-import { DeleteBasketItem } from '../../api';
+import { deleteBasketItem } from '../../api/basket';
 
 interface ToastData {
   active: boolean;
@@ -50,7 +50,7 @@ function BasketTabs({ setShowAlert }: BasketTabsProps) {
 
   // 예약 불가능 숙소 모두 삭제
   const deleteAllUnavailable = () => {
-    unavailableIds.forEach((id: number) => DeleteBasketItem(id));
+    unavailableIds.forEach((id: number) => deleteBasketItem(id));
     setBasketData(
       basketData.filter((product: BasketData) => !unavailableIds.includes(product.basketId)),
     );
@@ -59,7 +59,7 @@ function BasketTabs({ setShowAlert }: BasketTabsProps) {
 
   // 예약 가능 숙소 모두 삭제
   const deleteAllAvailable = () => {
-    availableIds.forEach((id: number) => DeleteBasketItem(id));
+    availableIds.forEach((id: number) => deleteBasketItem(id));
     setBasketData(
       basketData.filter((product: BasketData) => !availableIds.includes(product.basketId)),
     );

--- a/src/pages/MyPage/MyPageReservation/MyPageReservationCard.tsx
+++ b/src/pages/MyPage/MyPageReservation/MyPageReservationCard.tsx
@@ -6,10 +6,10 @@ import { StarFilled } from '@ant-design/icons';
 import { theme } from '../../../styles/theme';
 import { MyPageReservationData } from '../../../@types/interface';
 import { handleBadgeColor } from '../../../utils/handleBadgeColor';
-import { CancelReservation } from '../../../api';
 import { changeCategoryReverseFormat, changeStarFormat, countDay } from '../../../utils/utils';
 import DefaultModal from '../../../components/Modal/DefaultModal';
 import { myPageReservationDataState } from '../../../states/atom';
+import { postCancelReservation } from '../../../api/mypage';
 
 interface MyPageReservationCardProps {
   item: MyPageReservationData;
@@ -39,7 +39,7 @@ function MyPageReservationCard({ item }: MyPageReservationCardProps) {
 
   const cancelReservation = async () => {
     try {
-      await CancelReservation(item.reservationId);
+      await postCancelReservation(item.reservationId);
       setReservationData(
         reservationData.filter(
           (product: MyPageReservationData) => product.reservationId !== item.reservationId,


### PR DESCRIPTION
## 개요

Close #114 

- 장바구니, 위시리스트, 마이페이지(예약내역) api 분리
- 함수명 파스칼케이스로 작성했던 것을 카멜케이스로 변경

## 구현 사항

- [x] 장바구니 API 함수 분리
- [x] 위시리스트 API 함수 분리
- [x] 마이페이지(예약내역만) API 함수 분리
- [x] 함수 이름 파스칼케이스 -> 카멜케이스로 변경

## 추후 작업 예정

- 비동기 응답(반환값)의 에러 처리하는 것까지 api 함수 내에서 작성
- 비동기 응답(반환값)의 타입 없는 것에 타입 추가