### PR TITLE
[#116] 장바구니, 위시리스트, 마이페이지(예약내역) API 함수 내부 로직 수정

### DIFF
--- a/src/api/basket.ts
+++ b/src/api/basket.ts
@@ -1,9 +1,15 @@
+import { BasketData } from '../@types/interface';
 import { clientToken } from './index';
 
 // 장바구니 목록 가져오기
 export const getBasket = async () => {
-  const res = await clientToken.get('/basket');
-  return res;
+  try {
+    const response = await clientToken.get('/basket');
+    return response.data.data as BasketData[];
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };
 
 // 장바구니 삭제

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -20,8 +20,13 @@ export const getMyPageReservationList = async () => {
 
 // 마이페이지 > 예약 취소 내역 가져오기
 export const getMyPageCancelledList = async () => {
-  const res = await clientToken.get('/reservation/canceled');
-  return res;
+  try {
+    const response = await clientToken.get('/reservation/canceled');
+    return response.data.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };
 
 // 마이페이지 > 리뷰 작성

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -9,8 +9,13 @@ export const postCancelReservation = async (reservationId: number) => {
 
 // 마이페이지 > 예약 내역 가져오기
 export const getMyPageReservationList = async () => {
-  const res = await clientToken.get('/reservation');
-  return res;
+  try {
+    const response = await clientToken.get('/reservation');
+    return response.data.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };
 
 // 마이페이지 > 예약 취소 내역 가져오기

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -1,4 +1,4 @@
-import { AddReviewData } from '../@types/interface';
+import { AddReviewData, MyPageReservationData } from '../@types/interface';
 import { clientToken } from './index';
 
 // 마이페이지 > 예약 취소 요청 API
@@ -11,7 +11,7 @@ export const postCancelReservation = async (reservationId: number) => {
 export const getMyPageReservationList = async () => {
   try {
     const response = await clientToken.get('/reservation');
-    return response.data.data;
+    return response.data.data as MyPageReservationData[];
   } catch (error) {
     console.error(error);
     throw error;
@@ -22,7 +22,7 @@ export const getMyPageReservationList = async () => {
 export const getMyPageCancelledList = async () => {
   try {
     const response = await clientToken.get('/reservation/canceled');
-    return response.data.data;
+    return response.data.data as MyPageReservationData[];
   } catch (error) {
     console.error(error);
     throw error;

--- a/src/api/mypage.ts
+++ b/src/api/mypage.ts
@@ -31,9 +31,14 @@ export const getMyPageCancelledList = async () => {
 
 // 마이페이지 > 리뷰 작성
 export const submitReview = async (reservationId: number, reviewData: AddReviewData) => {
-  const res = await clientToken.post(
-    `/review/reservations/${reservationId}`,
-    JSON.stringify(reviewData),
-  );
-  return res;
+  try {
+    const response = await clientToken.post(
+      `/review/reservations/${reservationId}`,
+      JSON.stringify(reviewData),
+    );
+    return response.data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };

--- a/src/api/wishlist.ts
+++ b/src/api/wishlist.ts
@@ -1,7 +1,13 @@
+import { WishlistData } from '../@types/interface';
 import { clientToken } from './index';
 
 // 위시리스트 목록 불러오기
 export const getWishlist = async () => {
-  const res = await clientToken.get('/wishlist');
-  return res;
+  try {
+    const response = await clientToken.get('/wishlist');
+    return response.data.data as WishlistData[];
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 };

--- a/src/pages/AddReview/AddReviewForm.tsx
+++ b/src/pages/AddReview/AddReviewForm.tsx
@@ -65,12 +65,9 @@ function AddReviewForm() {
           console.log('등록 완료!');
           successFunction();
           navigate('/mypage');
-        } else if (response.data.message === '해당 작업을 수행 할 권한이 존재하지 않습니다.') {
-          console.log('해당 작업을 수행 할 권한이 존재하지 않습니다.');
-          failFunction('해당 작업을 수행 할 권한이 존재하지 않습니다.');
-        } else if (response.data.message === '존재하지 않는 reservationId입니다.') {
-          console.log('존재하지 않는 reservationId입니다.');
-          failFunction('해당하는 예약이 없습니다.');
+        } else {
+          console.log(response.data.message);
+          failFunction(response.data.message);
         }
       } catch (error) {
         console.log(error);
@@ -83,12 +80,9 @@ function AddReviewForm() {
           console.log('등록 완료!');
           successFunction();
           navigate('/mypage');
-        } else if (response.data.message === '해당 작업을 수행 할 권한이 존재하지 않습니다.') {
-          console.log('해당 작업을 수행 할 권한이 존재하지 않습니다.');
-          failFunction('해당 작업을 수행 할 권한이 존재하지 않습니다.');
-        } else if (response.data.message === '존재하지 않는 reservationId입니다.') {
-          console.log('존재하지 않는 reservationId입니다.');
-          failFunction('해당하는 예약이 없습니다.');
+        } else {
+          console.log(response.data.message);
+          failFunction(response.data.message);
         }
       } catch (err) {
         console.error(err);

--- a/src/pages/Basket/index.tsx
+++ b/src/pages/Basket/index.tsx
@@ -26,15 +26,14 @@ function Basket() {
   const fetchData = async () => {
     try {
       const response = await getBasket();
-      const { data } = response.data;
 
       // Sort the data by startDate
-      data.sort(
+      response.sort(
         (a: BasketData, b: BasketData) =>
           new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
       );
 
-      setBasketData(data);
+      setBasketData(response);
     } catch (err) {
       console.log(err);
     }

--- a/src/pages/MyPage/MyPageReservation/index.tsx
+++ b/src/pages/MyPage/MyPageReservation/index.tsx
@@ -28,15 +28,14 @@ function MyPageReservation() {
   // 예약 취소 목록 조회
   const fetchCancelledData = async () => {
     const response = await getMyPageCancelledList();
-    const { data } = response.data;
 
     // Sort the data by startDate
-    data.sort(
+    response.sort(
       (a: MyPageReservationData, b: MyPageReservationData) =>
         new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
     );
 
-    setCancelledList(data);
+    setCancelledList(response);
   };
 
   useEffect(() => {

--- a/src/pages/MyPage/MyPageReservation/index.tsx
+++ b/src/pages/MyPage/MyPageReservation/index.tsx
@@ -15,15 +15,14 @@ function MyPageReservation() {
   // 예약 목록 조회
   const fetchReservationData = async () => {
     const response = await getMyPageReservationList();
-    const { data } = response.data;
 
     // Sort the data by startDate
-    data.sort(
+    response.sort(
       (a: MyPageReservationData, b: MyPageReservationData) =>
         new Date(a.startDate).getTime() - new Date(b.startDate).getTime(),
     );
 
-    setReservationData(data);
+    setReservationData(response);
   };
 
   // 예약 취소 목록 조회

--- a/src/pages/WishList/index.tsx
+++ b/src/pages/WishList/index.tsx
@@ -15,7 +15,7 @@ function WishList() {
   const fetchWishlistData = async () => {
     try {
       const response = await getWishlist();
-      setWishlistData(response.data.data);
+      setWishlistData(response);
     } catch (err) {
       console.log(err);
     }


### PR DESCRIPTION
## 개요
Close #116 

- 장바구니, 위시리스트, 마이페이지(예약내역) API 함수 내부 로직 수정했습니다.

## 구현 사항

- [x] 비동기 응답(반환값)의 에러 처리까지 api 함수 내에서 작성
  - [ ] 리뷰 작성 페이지 에러 처리 부분 제거 (api 함수에서 처리할 예정)
- [x] 비동기 응답(반환값)의 타입 없는 것에 타입 추가

## 고민한 점, 질문거리

리뷰 작성 컴포넌트에서 비동기 실행 결과에 따른 에러 처리를 작성했었는데
멘토님께서 컴포넌트에 작성하는 건 좋은 방법이 아닌 것같다고 하셨습니다.

그래서 api 함수 내부에서 에러 처리를 해줘야되는 것같은데 적절한 처리 방법을 찾지 못해서 멘토링 이후에 에러 처리 관련한 리팩토링 다시 시도하겠습니다!