### PR TITLE
[#137] 숙소 이미지 서스펜스/스켈레톤 적용

### DIFF
--- a/src/components/Loading/Skeleton.tsx
+++ b/src/components/Loading/Skeleton.tsx
@@ -1,0 +1,32 @@
+import { keyframes } from '@emotion/react';
+import styled from '@emotion/styled';
+import { theme } from '../../styles/theme';
+
+const Skeleton = () => {
+  return <StyledContainer />;
+};
+
+export default Skeleton;
+
+const load = keyframes`
+0% {
+        background-color: ${theme.colors.gray200}
+    }
+
+    50% {
+        background-color: ${theme.colors.gray300}
+    }
+
+    100% {
+        background-color: ${theme.colors.gray200}
+    }
+    
+`;
+
+const StyledContainer = styled.div`
+  display: flex;
+  width: 100%;
+  height: 100%;
+  border-radius: inherit;
+  animation: ${load} 1.8s infinite;
+`;

--- a/src/pages/Home/HomeCard.tsx
+++ b/src/pages/Home/HomeCard.tsx
@@ -1,12 +1,15 @@
+import React, { Suspense } from 'react';
 import styled from '@emotion/styled';
 import { useNavigate } from 'react-router-dom';
 import { StarFilled } from '@ant-design/icons';
 import { Text } from '@chakra-ui/react';
 import { theme } from '../../styles/theme';
 import { HomeCardProps } from '../../@types/interface';
-import HomeSwiper from './HomeSwiper';
 import { changeCategoryReverseFormat, changeStarFormat, cutStringLength } from '../../utils/utils';
 import HomeHeart from './HomeHeart';
+import Skeleton from '../../components/Loading/Skeleton';
+
+const Swiper = React.lazy(() => import('./HomeSwiper'));
 
 const HomeCard = ({ id, name, images, category, score, price, isLiked }: HomeCardProps) => {
   const navigate = useNavigate();
@@ -15,7 +18,9 @@ const HomeCard = ({ id, name, images, category, score, price, isLiked }: HomeCar
     <StyledCard>
       <StyledImgWrapper>
         <HomeHeart liked={isLiked} size="20px" id={String(id)} />
-        <HomeSwiper images={images} borderRadius="8px" id={id} />
+        <Suspense fallback={<Skeleton />}>
+          <Swiper images={images} borderRadius="8px" id={id} />
+        </Suspense>
       </StyledImgWrapper>
       <StyledInfoContainer
         onClick={() => {


### PR DESCRIPTION
## 개요

: 숙소 이미지에 서스펜스 적용 및 스켈레톤 적용했습니다.

## 스크린샷

  
## 구현 사항

- [x] 숙소 이미지 서스펜스 적용

## 고민한 점, 질문거리

- 스켈레톤 UI의 길이는 주지 않았습니다. 따라서 서버 상태가 원활할 경우 유저가 봤을 때 티나지 않을거에요
- 서스펜스를 사용하면, 메인페이지의 성능 향상에 약간 도움이 될까 적용해봤습니다
- 유저 입장에서도 끊기면서 이미지가 로딩되는게 아니라, UX 상으로도 더 좋을거라 생각해요ㅎ